### PR TITLE
Handle .doc uploads with correct loader

### DIFF
--- a/rag_utils.py
+++ b/rag_utils.py
@@ -4,7 +4,12 @@ import tempfile
 from typing import List, Optional, Tuple
 
 from langchain_openai import OpenAIEmbeddings, ChatOpenAI
-from langchain_community.document_loaders import PyPDFLoader, Docx2txtLoader, TextLoader
+from langchain_community.document_loaders import (
+    PyPDFLoader,
+    Docx2txtLoader,
+    TextLoader,
+    UnstructuredWordDocumentLoader,
+)
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_community.vectorstores import FAISS
 
@@ -45,10 +50,13 @@ def load_docs_from_files(files) -> List:
         if ext == "pdf":
             loader = PyPDFLoader(tmp_path)
             docs.extend(loader.load())
-        elif ext in ("docx", "doc"):
+        elif ext == "docx":
             loader = Docx2txtLoader(tmp_path)
             docs.extend(loader.load())
-        elif ext in ("txt",):
+        elif ext == "doc":
+            loader = UnstructuredWordDocumentLoader(tmp_path)
+            docs.extend(loader.load())
+        elif ext == "txt":
             loader = TextLoader(tmp_path, encoding="utf-8")
             docs.extend(loader.load())
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ docx2txt>=0.8
 python-dotenv>=1.0.1
 pydantic>=2.7.1
 tenacity>=8.3.0
+unstructured>=0.15.0


### PR DESCRIPTION
## Summary
- fix document loading to use `UnstructuredWordDocumentLoader` for `.doc` files
- add `unstructured` dependency to requirements

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement unstructured>=0.15.0)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8887b63a88328bc11279cbd0956e5